### PR TITLE
Don't try to muck with git unnecessarily when starting a release.

### DIFF
--- a/releng/00-release-start
+++ b/releng/00-release-start
@@ -101,6 +101,11 @@ def main(next_ver: str, commit: bool = True) -> int:
         print('not committing')
         return 0
 
+    out = run_capture(["git", "status", "--porcelain"])
+    if not out:
+        print("No changes needed, all good.")
+        return 0
+    
     with check(f"Committing changes..."):
         gitdir = run_capture(['git', 'rev-parse', '--git-dir'])
         with open(os.path.join(gitdir, 'GITGUI_MSG'), 'w') as msgfile:

--- a/releng/00-release-start
+++ b/releng/00-release-start
@@ -70,10 +70,13 @@ def main(next_ver: str, commit: bool = True) -> int:
 
     workbranch = current_release_branch
     base_branch = release_branch
-    if branch_exists('origin/' + current_release_branch):
-        with check(f"Checking out {current_release_branch} and making it up to date with {release_branch}"):
+    if branch_exists(current_release_branch):
+        with check(f"Checking out {current_release_branch}"):
             run(["git", "checkout", current_release_branch])
-            run(["git", "pull", "origin", current_release_branch])
+
+        if branch_exists("origin/" + current_release_branch):
+            with check(f"Bringing our branch it up to date with origin/{release_branch}"):
+                run(["git", "pull", "origin", current_release_branch])
     else:
         with check(f"Creating {current_release_branch}"):
             run(["git", "checkout", "-b", current_release_branch])

--- a/releng/00-release-start
+++ b/releng/00-release-start
@@ -83,7 +83,7 @@ def main(next_ver: str, commit: bool = True) -> int:
     if not checker.ok:
         return 1
     run(["git", "merge", f"origin/{release_branch}"])
-    with check(f"Checking if there are conflicts in merge"):
+    with check(f"Checking for clean branch with no conflicts..."):
         out = run_capture(["git", "status", "--porcelain"])
         if out:
             raise AssertionError(f"Merge conflicts on {current_release_branch}. Resolve these, then rerun this scrip")


### PR DESCRIPTION
Don't die if the `rel/` branch already exists (but do die if it exists, the remote exists, and we can't pull from the remote).
Don't try to `git commit` if the CHANGELOG and releaseNotes are already up to date.
